### PR TITLE
fix protected override

### DIFF
--- a/lib/dashing.js
+++ b/lib/dashing.js
@@ -29,8 +29,12 @@ module.exports.Dashing = function Dashing() {
   dashing.default_dashboard = null;
   dashing.port = (process.env.PORT || 3030);
 
-  dashing._protected = function(req, res, next) {
+  dashing.protected = function(req, res, next) {
     next();
+  };
+
+  dashing._protected = function(req, res, next) {
+    dashing.protected(req, res, next);
   }
 
   var expressLoggerOptions = {

--- a/templates/project/server.js
+++ b/templates/project/server.js
@@ -4,7 +4,7 @@ var dashing = require('dashing-js').Dashing();
 //dashing.auth_token = 'YOUR_AUTH_TOKEN';
 
 /*
-dashing._protected = function(req, res, next) {
+dashing.protected = function(req, res, next) {
   // Put any authentication code you want in here.
   // This method is run before accessing any resource.
   // if (true) next();


### PR DESCRIPTION
Because express app.get runs before you get a chance to override
_protected, overriding it in server.js fails.  If however, _protected
itself calls another property of the dashing object, it can be overriden
