### PR TITLE
use dashingjs as a module rather as a server

### DIFF
--- a/lib/dashing.js
+++ b/lib/dashing.js
@@ -32,8 +32,6 @@ module.exports.Dashing = function Dashing(options) {
     _.extend(OPTIONS.dashing, options.dashing);
   }
 
-  console.log(OPTIONS);
-
   dashing.root = OPTIONS.dashing.root;
   dashing.NODE_ENV = process.env.NODE_ENV || 'development';
   dashing.view_engine = process.env.VIEW_ENGINE || 'jade';

--- a/lib/dashing.js
+++ b/lib/dashing.js
@@ -2,36 +2,60 @@ var fs = require('fs')
   , path = require('path')
   , express = require('express')
   , Mincer = require('mincer')
-  , coffee = require('coffee-script');
+  , coffee = require('coffee-script')
+  , _ = require('underscore');
 
 global.SCHEDULER = require('node-schedule');
 
-module.exports.logger = logger = require('./logger');
-module.exports.Dashing = function Dashing() {
-  var dashing = {};
-  dashing.root = path.resolve(__dirname, '../../..');
-  dashing.NODE_ENV = process.env.NODE_ENV || 'development';
+/**
+ * OPTIONS for mincer and dashing server
+ */
+var OPTIONS = {
+  dashing: {},
+  mincer: {}
+};
 
+OPTIONS.dashing.root = path.resolve(__dirname, '../../..');
+OPTIONS.dashing.public_folder = OPTIONS.dashing.root + '/public';
+OPTIONS.dashing.view = OPTIONS.dashing.root + '/dashboards';
+OPTIONS.mincer.asset_prefix = '/assets';
+
+module.exports.logger = logger = require('./logger');
+module.exports.Dashing = function Dashing(options) {
+  var dashing = {};
+
+  if(options.mincer){
+    _.extend(OPTIONS.mincer, options.mincer);
+  }
+
+  if(options.dashing){
+    _.extend(OPTIONS.dashing, options.dashing);
+  }
+
+  console.log(OPTIONS);
+
+  dashing.root = OPTIONS.dashing.root;
+  dashing.NODE_ENV = process.env.NODE_ENV || 'development';
   dashing.view_engine = process.env.VIEW_ENGINE || 'jade';
 
   dashing.mincer = {};
   dashing.mincer.environment = new Mincer.Environment();
-  dashing.mincer.assets_prefix = '/assets';
-  dashing.mincer.environment.appendPath('assets/javascripts');
-  dashing.mincer.environment.appendPath('assets/stylesheets');
-  dashing.mincer.environment.appendPath('assets/fonts');
-  dashing.mincer.environment.appendPath('assets/images');
-  dashing.mincer.environment.appendPath('widgets');
+  dashing.mincer.assets_prefix = OPTIONS.mincer.asset_prefix;
+  dashing.mincer.environment.appendPath(OPTIONS.dashing.root + '/assets/javascripts');
+  dashing.mincer.environment.appendPath(OPTIONS.dashing.root + '/assets/stylesheets');
+  dashing.mincer.environment.appendPath(OPTIONS.dashing.root + '/assets/fonts');
+  dashing.mincer.environment.appendPath(OPTIONS.dashing.root + '/assets/images');
+  dashing.mincer.environment.appendPath(OPTIONS.dashing.root + '/widgets');
   dashing.mincer.environment.appendPath(path.resolve(__dirname, '../javascripts'));
 
-  dashing.public_folder = dashing.root + '/public';
-  dashing.views = dashing.root + '/dashboards';
+  dashing.public_folder = OPTIONS.dashing.public_folder;
+  dashing.views = OPTIONS.dashing.view;
   dashing.default_dashboard = null;
   dashing.port = (process.env.PORT || 3030);
 
   dashing._protected = function(req, res, next) {
     next();
-  }
+  };
 
   var expressLoggerOptions = {
     format: 'dev',

--- a/templates/project/index.js
+++ b/templates/project/index.js
@@ -1,0 +1,20 @@
+var dashing = require('dashing-js').Dashing({
+  // optional override for overriding dashing server settings
+});
+
+// Set your auth token here
+//dashing.auth_token = 'YOUR_AUTH_TOKEN';
+
+/*
+dashing._protected = function(req, res, next) {
+  // Put any authentication code you want in here.
+  // This method is run before accessing any resource.
+  // if (true) next();
+}
+*/
+
+// Set your default dashboard here
+//dashing.default_dashboard = 'mydashboard';
+
+// export dashing.app to be used within another module
+exports = module.exports = dashing.app;


### PR DESCRIPTION
I wanted to use dashing to be part of our internal dashboard, but want to use it inside another nodejs server rather a separate server. These are the changes I made in order to make it work.
- add index.js that export `dashing.app` as a module
- add root to mincer paths for it to be look up correctly when dashing is a subfolder of the main projet
- add options to override some paths
