### PR TITLE
fix: start jobs when dashing starts not during require

### DIFF
--- a/lib/dashing.js
+++ b/lib/dashing.js
@@ -26,6 +26,7 @@ module.exports.Dashing = function Dashing() {
 
   dashing.public_folder = dashing.root + '/public';
   dashing.views = dashing.root + '/dashboards';
+  dashing.settings = dashing.root + '/settings';
   dashing.default_dashboard = null;
   dashing.port = (process.env.PORT || 3030);
 
@@ -130,9 +131,16 @@ module.exports.Dashing = function Dashing() {
     var dashboard = req.params.dashboard;
     fs.exists([dashing.views, dashboard + '.' + dashing.view_engine].join(path.sep), function(exists) {
       if (exists) {
-        res.render(dashboard, {
+        var templateVars = {
           dashboard: dashboard,
           request: req
+        };
+        var settingsPath = [dashing.settings, dashboard + '.json'].join(path.sep);
+        fs.exists(settingsPath, function(exists) {
+          if (exists) {
+            templateVars.settings = require(settingsPath);
+          }
+          res.render(dashboard, templateVars);
         });
       } else {
         res.status(404).sendfile(dashing.public_folder + '/404.html');

--- a/lib/dashing.js
+++ b/lib/dashing.js
@@ -221,22 +221,34 @@ module.exports.Dashing = function Dashing() {
     }
   });
 
-  // Lod jobs files
-  var job_path = process.env.JOB_PATH || [dashing.root, 'jobs'].join(path.sep);
-  fs.readdir(job_path, function(err, files) {
-    if (err) throw err;
-    for (var i in files) {
-      var file = [job_path, files[i]].join(path.sep);
-      if (file.match(/(\w*)\.job\.(js|coffee)$/)) {
-        logger.log('Loading job file:', files[i]);
-        require(file);
+  function start_jobs() {
+    // Load jobs files
+    var job_path = process.env.JOB_PATH || [dashing.root, 'jobs'].join(path.sep);
+    fs.readdir(job_path, function(err, files) {
+      if (err) throw err;
+      for (var i in files) {
+        var file = [job_path, files[i]].join(path.sep);
+        if (file.match(/(\w*)\.job\.(js|coffee)$/)) {
+          logger.info('Loading job file:', files[i]);
+          require(file);
+        }
       }
-    }
-  });
+    });
+  }
 
-  dashing.start = function() {
+  function start_express() {
     app.listen(dashing.port);
     logger.info('Listening on http://0.0.0.0:' + dashing.port + (process.env.__daemon === 'false' ? ', CTRL+C to stop' : ''));
+  }
+
+  dashing.start = function() {
+    try {
+      start_jobs();
+      start_express();
+    } catch(e) {
+      logger.error("Unable to start dashing");
+      logger.error(e.toString()); // winston is not catching these?
+    }
   }
   dashing.app = app;
   return dashing;


### PR DESCRIPTION
Currently, dashing-js will [lookup and require all jobs upon dashing load](https://github.com/fabiocaseri/dashing-js/blob/master/lib/dashing.js#L217-L227).  This comes as somewhat of a surprising to those loading dashing, making changes to configuration, then `.start()`ing.

This PR moves job start and express start into the `Dashing.start` method.
